### PR TITLE
Fix API Documentation Trailing Slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using the National Archives Catalog API
 
 ## What is the API?
 
-The [National Archives Catalog API](https://catalog.archives.gov/api/v2/api-docs) is a read–write web API for the online catalog for the National Archives.
+The [National Archives Catalog API](https://catalog.archives.gov/api/v2/api-docs/) is a read–write web API for the online catalog for the National Archives.
 
 The URL path for the API is: [`https://catalog.archives.gov/api/v2/api-docs`](https://catalog.archives.gov/api/v2/api-docs)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The system imposes limits on how much data you can request (based on maximum row
 
 The current (and so far only) version of our catalog API is v1, which was released in December 2014. As improvements are made to the current version, we will try to ensure backwards compatibility.
 
-The base URL, [`https://catalog.archives.gov/api/v2/api-docs/`](https://catalog.archives.gov/api/v2/aoi-docs/), will always contain the API version.
+The base URL, [`https://catalog.archives.gov/api/v2/api-docs/`](https://catalog.archives.gov/api/v2/api-docs/), will always contain the API version.
 
 ## Does NARA have other datasets and APIs not included in the catalog API?
 


### PR DESCRIPTION
A trailing slash was missing from the documentation link causing a blank page to be rendered:

<img width="1435" alt="Screenshot 2024-01-04 at 19 23 05" src="https://github.com/usnationalarchives/Catalog-API/assets/15347255/69b101a3-6e09-44f8-a0fe-44ba146b4354">
